### PR TITLE
Offload modal generation to Ajax

### DIFF
--- a/nt_training/templates/nt_training/base.html
+++ b/nt_training/templates/nt_training/base.html
@@ -15,7 +15,10 @@
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
 
 		<!-- JQuery -->
-		<script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+		<script
+		  src="https://code.jquery.com/jquery-3.2.1.min.js"
+		  integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
+		  crossorigin="anonymous"></script>
 
 		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js" integrity="sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1" crossorigin="anonymous"></script>
 
@@ -83,7 +86,8 @@
 				<p>No content defined.</p>
 			{% endblock %}
 		</div>
-
+		<div class="modal" tabindex="-1" role="dialog" id="modalwizard">
+		</div>
 		<!-- Footer -->
 		<div class="container">
 			<hr>
@@ -105,6 +109,21 @@
 				$(function () {
 			  	$('[data-toggle="tooltip"]').tooltip() // Enable Boostrap tooltips
 				});
+			</script>
+
+			<!-- Only render modals onclick -->
+			<script>
+	      $('.modal-href').on('click', function() {
+	      	$('#modalwizard').modal('toggle');
+	      	$("#modalwizard").load("/training/"+this.id+"/?modal=True .modal-dialog");
+	      });
+
+	      // Remove contents of modal once it's dismissed to prevent overlap.
+	      $('#modalwizard').on('hidden.bs.modal', function (e) {
+	      	while (this.hasChildNodes()) {
+					    this.removeChild(this.lastChild);
+					};
+	      });
 			</script>
 
 			<!-- Filtering of people -->

--- a/nt_training/templates/nt_training/template_tags/training-card.html
+++ b/nt_training/templates/nt_training/template_tags/training-card.html
@@ -70,7 +70,7 @@ From nt_spec.py:
 						{% if item.category == dept %}
 							<tr class="
 								{{ dept|slugify }} 
-								{% if card_settings.modals == True %}clickme{% endif %} 
+								{% if card_settings.modals == True %}clickme modal-href{% endif %} 
 								{% if card_settings.colour_bands == True %}
 									{% if item.trainingId in person_achieved_points or item in session_boxes %}
 										table-success
@@ -78,9 +78,7 @@ From nt_spec.py:
 										table-danger d-none
 									{% endif %}
 								{% endif %}"
-								{% if card_settings.modals == True %}
-									data-toggle="modal" data-target="#{{item.pk}}-Modal"
-								{% endif %}>
+								id="{{item.pk}}">								
 								<td>
 									{% if card_settings.checkboxes == True %}
 										<input type="checkbox" name="trainingId" value="{{ item.pk }}" id="id_trainingId_{{ forloop.counter }}" class="form-controls checkbox-{{dept|slugify}}"
@@ -93,38 +91,6 @@ From nt_spec.py:
 								</td>
 								<td {% if card_settings.modals == True %}class="underhover"{% endif %}>{% if item.safety == True %}<i class="fa fa-exclamation-circle text-danger" aria-label="Exclamation point" title="Safety critical"></i>&nbsp;{% endif %}{{ item.trainingTitle }}</td>
 							</tr>
-							{% if card_settings.modals == True %}
-								{# Don't show the modal if we're editing a training session #}
-								<div class="modal fade" id="{{item.pk}}-Modal" tabindex="-1" role="dialog" aria-labelledby="{{item.trainingId}}">
-									<div class="modal-dialog modal-lg" role="document">
-										<div class="modal-content">
-											<div class="modal-header">
-							        	<h4 class="modal-title">{% if item.safety == True %}<i class="fa fa-exclamation-circle text-danger" aria-label="Exclamation point" title="Safety critical"></i>&nbsp;{% endif %}{{ item.trainingId }} &ndash; {{ item.trainingTitle }}</h4>
-							      	</div>
-							      	<div class="modal-body">
-							      		{{ item.description|linebreaks }}
-							      		<hr>
-												{% id_people item.pk as people %}
-												<!-- Trainers -->
-												{% if not people.trainers %}
-													<p class="text-muted">This has not been taught by anyone.</p>
-												{% else %}
-													<p>Has been taught by: {% for p in people.trainers %}<a href="{% url 'nt_training:ntPerson' p.slug %}">{{ p|title }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}.</p>
-												{% endif %}
-							      		<!-- Trainees -->
-												{% if not people.trainees %}
-													<p class="text-muted">This has not been taught to any current student.</p>
-												{% else %}
-												<p>Current students this has been taught to: {% for p in people.trainees %}<a href="{% url 'nt_training:ntPerson' p.slug %}">{{ p|title }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}.</p>
-												{% endif %}
-							      	</div>
-							      	<div class="modal-footer">
-							      		<button type="button" class="btn btn-secondary" data-dismiss="modal"><i class="fa fa-fw fa-lg fa-times-circle-o" aria-hidden="True"></i> Close</button>
-							      	</div>
-							      </div>
-							    </div>
-							  </div>
-						  {% endif %}
 						{% endif %}
 					{% endfor %}
 					{% tech_status person=None dept=dept as status %}

--- a/nt_training/templates/nt_training/training-detail.html
+++ b/nt_training/templates/nt_training/training-detail.html
@@ -1,0 +1,61 @@
+{% extends 'nt_training/base.html' %}
+{% block title %}{{ item.trainingTitle }}{% endblock %}
+
+{% load nt_spec %}
+{% load nt_training_sessions %}
+{% load widget_tweaks %}
+
+{% block content %}
+
+{% if request.GET.modal == "True"  %}
+	<div class="modal-dialog modal-lg" role="document" id="modal-content">
+		<div class="modal-content">
+			<div class="modal-header">
+      	<h4 class="modal-title">{% if item.safety == True %}<i class="fa fa-exclamation-circle text-danger" aria-label="Exclamation point" title="Safety critical"></i>&nbsp;{% endif %}{{ item.trainingId }} &ndash; {{ item.trainingTitle }}</h4>
+    	</div>
+    	<div class="modal-body">
+    		{{ item.description|linebreaks }}
+    		<hr>
+				{% id_people item.pk as people %}
+				<!-- Trainers -->
+				{% if not people.trainers %}
+					<p class="text-muted">This has not been taught by anyone.</p>
+				{% else %}
+					<p>Has been taught by: {% for p in people.trainers %}<a href="{% url 'nt_training:ntPerson' p.slug %}">{{ p|title }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}.</p>
+				{% endif %}
+    		<!-- Trainees -->
+				{% if not people.trainees %}
+					<p class="text-muted">This has not been taught to any current student.</p>
+				{% else %}
+				<p>Current students this has been taught to: {% for p in people.trainees %}<a href="{% url 'nt_training:ntPerson' p.slug %}">{{ p|title }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}.</p>
+				{% endif %}
+    	</div>
+    	<div class="modal-footer">
+    		<button type="button" class="btn btn-secondary closeModal" data-dismiss="modal"><i class="fa fa-fw fa-lg fa-times-circle-o" aria-hidden="True"></i> Close</button>
+    	</div>
+    </div>
+  </div>
+{% else %}
+	<h4>{% if item.safety == True %}<i class="fa fa-exclamation-circle text-danger" aria-label="Exclamation point" title="Safety critical"></i>&nbsp;{% endif %}{{ item.trainingId }} &ndash; {{ item.trainingTitle }}</h4>
+
+	<div class="row">
+		<div class="col">
+			{{ item.description|linebreaks }}
+			<hr>
+			{% id_people item.pk as people %}
+			<!-- Trainers -->
+			{% if not people.trainers %}
+				<p class="text-muted">This has not been taught by anyone.</p>
+			{% else %}
+				<p>Has been taught by: {% for p in people.trainers %}<a href="{% url 'nt_training:ntPerson' p.slug %}">{{ p|title }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}.</p>
+			{% endif %}
+  		<!-- Trainees -->
+			{% if not people.trainees %}
+				<p class="text-muted">This has not been taught to any current student.</p>
+			{% else %}
+			<p>Current students this has been taught to: {% for p in people.trainees %}<a href="{% url 'nt_training:ntPerson' p.slug %}">{{ p|title }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}.</p>
+			{% endif %}
+		</div>
+	</div>
+{% endif %}
+{% endblock %}

--- a/nt_training/urls.py
+++ b/nt_training/urls.py
@@ -29,7 +29,7 @@ urlpatterns = [
 	#/training
 	url(r'^training/$', views.TrainingView.as_view(), name='ntCategory'),
 	#/training/id
-	url(r'^training/(?P<trainingId>[0-9]+)/$', views.TrainingIdView.as_view(), name='ntTrainingId'),
+	url(r'^training/(?P<pk>[0-9]+)/$', views.TrainingDetailView.as_view(), name='ntTrainingDetail'),
 
 	# Training Session Views
 	#/training/session (List view)

--- a/nt_training/views.py
+++ b/nt_training/views.py
@@ -62,9 +62,10 @@ class TrainingView(generic.ListView):
 	template_name = "nt_training/training.html"
 	context_object_name = "training"
 
-class TrainingIdView(generic.DetailView):
-	template_name = "nt_training/training-single.html"
+class TrainingDetailView(generic.DetailView):
+	template_name = "nt_training/training-detail.html"
 	model = Training_Spec
+	context_object_name = "item"
 
 class SessionView(generic.ListView):
 	template_name = "nt_training/session.html"


### PR DESCRIPTION
- Remove modal generation from page load
- Add an empty modal to the page
- Move to jquery min, rather than slim, which allows for Ajax
- Populate this on click
- Introduce (navigationally hidden) single pages for training points (training/<ID>)

Reduce database calls and generally speed up all the things.

(87 queries down to 12 using preliminary data)